### PR TITLE
Add in plugins to source, add more logging to audio and change to .wav for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,8 @@ or
     sudo npm update -g cordova
 
 
-### Add support for the iOS or Android SDK
-After cloning this repository, in the project root folder, run one of the following (depending on the platform you wish to develop for):
-
-    cordova platforms add ios
-    cordova platforms add android
-
-### Add plugins
-
-    cordova plugin add cordova-plugin-device  # Basic plugin
-    cordova plugin add cordova-plugin-console  # Basic plugin
-    cordova plugin add cordova-plugin-dialogs  # Native dialogs plugin
-    cordova plugin add cordova-plugin-statusbar  # Status bar plugin
-    cordova plugin add cordova-plugin-geolocation  # Geolocation plugin
-    cordova plugin add cordova-plugin-contacts  # Contacts plugin
-    cordova plugin add cordova-plugin-camera  # Camera plugin
-    cordova plugin add cordova-plugin-media  # For audio recording and playback 
+### Platforms and plugins
+These are managed in [config.xml](https://cordova.apache.org/docs/en/latest/config_ref/) and checked into source control.
 
 ## Building the Project
 ### Building for iOS
@@ -66,6 +52,12 @@ or
 Then run the application in the iOS emulator:
 
     cordova emulate ios
+
+Or on device, use:
+
+    cordova run ios --device
+
+You can set up Safari Web Inspector debugging with [these instructions](http://geeklearning.io/apache-cordova-and-remote-debugging-on-ios/).
     
 
 ### Building for Android

--- a/config.xml
+++ b/config.xml
@@ -8,7 +8,6 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
-    <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
@@ -23,4 +22,15 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
     </platform>
+    <engine name="android" spec="~5.2.2" />
+    <engine name="ios" spec="~4.2.1" />
+    <plugin name="cordova-plugin-whitelist" spec="1" />
+    <plugin name="cordova-plugin-console" spec="~1.0.3" />
+    <plugin name="cordova-plugin-device" spec="~1.1.2" />
+    <plugin name="cordova-plugin-dialogs" spec="~1.2.1" />
+    <plugin name="cordova-plugin-statusbar" spec="~2.1.3" />
+    <plugin name="cordova-plugin-geolocation" spec="~2.2.0" />
+    <plugin name="cordova-plugin-contacts" spec="~2.1.0" />
+    <plugin name="cordova-plugin-camera" spec="~2.2.0" />
+    <plugin name="cordova-plugin-media" spec="~2.3.0" />
 </widget>

--- a/www/js/EmployeeView.js
+++ b/www/js/EmployeeView.js
@@ -1,6 +1,16 @@
+function getFileName(email) {
+    var cleanEmail = email.replace(/[@\.]/g, "_");
+    if (device.platform === 'iOS') {
+        return "audio-" + cleanEmail + ".wav";
+    } else if (device.platform === 'Android') {
+        return "audio-" + cleanEmail + ".amr";
+    }
+}
+
 var EmployeeView = function(employee) {
 
     this.initialize = function() {
+        console.log('initialize');
         this.$el = $('<div/>');
         this.$el.on('click', '.add-location-btn', this.addLocation);
         this.$el.on('click', '.add-contact-btn', this.addToContacts);
@@ -28,7 +38,7 @@ var EmployeeView = function(employee) {
 
     this.addToContacts = function(event) {
         event.preventDefault();
-        console.log('addToContacts');
+        console.console.log('addToContacts');
         if (!navigator.contacts) {
             alert("Contacts API not supported", "Error");
             return;
@@ -84,51 +94,54 @@ var EmployeeView = function(employee) {
 	    navigator.notification.alert('Error code: ' + error.code, null, 'Capture Error');
 	};
 
-    function getFileName(email) {
-        // Replace @ and . with _ and add .amr extension
-        return "audio-" + email.replace(/[@\.]/g, "_") + ".amr";
-    }
-
     this.recordAudio = function(event) {
         var src = getFileName(employee.email);
+        console.log('recordAudio:new Media');
         var mediaRec = new Media(src,
             // success callback
             function() {
-                alert("Saved: " + src);
+                console.log("recordAudio:Saved: " + src);
             },
 
             // error callback
             function(err) {
-                alert("Audio Error: "+ JSON.stringify(err));
+                console.log("recordAudio:Error: "+ JSON.stringify(err));
             }
         );
 
         // Record audio
         mediaRec.startRecord();
+        console.log('recordAudio:startRecord');
 
         // Stop recording after 3 seconds
         setTimeout(function() {
+            console.log('recordAudio:stopRecord');
             mediaRec.stopRecord();
+            console.log('recordAudio:release');
             mediaRec.release();
+            console.log('recordAudio:done');
         }, 3000);
 
     };
 
     this.playAudio = function(event) {
         var src = getFileName(employee.email);
+        console.log('playAudio:getFileName: ' + src);
         var media = new Media(
             src, 
             function(){
-                // alert("media success: " + filePath);
+                console.log("playAudio:media success: " + src);
             }, 
             function(err){
-                alert("Error. Record an audio for this employee before selecting play. Error mssg: " + JSON.stringify(err));
+                console.log("playAudio:Error. Record an audio for this employee before selecting play. Error mssg: " + JSON.stringify(err));
             }, 
             function(status){
-                // alert("Status change: " + status);
+                console.log("playAudio:Status change: " + status);
             });
 
+        console.log('playAudio:play');
         media.play();
+        console.log('playAudio:done');
     };
 
     this.initialize();

--- a/www/js/EmployeeView.js
+++ b/www/js/EmployeeView.js
@@ -38,7 +38,7 @@ var EmployeeView = function(employee) {
 
     this.addToContacts = function(event) {
         event.preventDefault();
-        console.console.log('addToContacts');
+        console.log('addToContacts');
         if (!navigator.contacts) {
             alert("Contacts API not supported", "Error");
             return;


### PR DESCRIPTION
This uses `cordova plugin save` to take the plugins that have been added via the README docs, and write them out to `config.xml`.

It also adds in some logging and a small branch to make the proof-of-concept work on an iOS device.  And a link to how to set up debugging via Safari Web Inspector.
